### PR TITLE
Add support for sub-arrays (where buffer is bigger than expected).

### DIFF
--- a/Z85.js
+++ b/Z85.js
@@ -87,8 +87,8 @@
             let buffer = null;
             if (bytes instanceof ArrayBuffer) {
                 buffer = bytes;
-            } else if (bytes.buffer instanceof ArrayBuffer) {
-                buffer = bytes.buffer;
+            } else if (bytes.buffer instanceof ArrayBuffer && 'byteOffset' in bytes) {
+                buffer = bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
             } else if (Array.isArray(bytes)) {
                 buffer = new Uint8Array(bytes).buffer;
             }

--- a/test/test.js
+++ b/test/test.js
@@ -57,4 +57,20 @@ describe('Z85', () => {
 
         done();
     });
+    it('encodes subarrays', done => {
+        const expected = '3&*!G4H@';
+        const bytes = [0, 0, 0, 0xC, 0x0, 0xF, 0xF, 0xE, 0xE, 0, 0, 0, 0];
+        const uint1 = Uint8Array.from(bytes).slice(3, -4);
+        const uint2 = Uint8Array.from(bytes).subarray(3, -4);
+
+        const encoded1 = Z85.encode(uint1);
+        const encoded2 = Z85.encode(uint2);
+
+        assert.strictEqual(encoded1.length, expected.length);
+        assert.strictEqual(encoded2.length, expected.length);
+        assert.strictEqual(encoded1, expected);
+        assert.strictEqual(encoded2, expected);
+
+        done();
+    });
 });


### PR DESCRIPTION
Add support for sub-arrays (where buffer is bigger than expected).

This also fix NodeJS `Buffer`s as by default NodeJS creates them backed by a 8192 bytes long `ArrayBuffer`.